### PR TITLE
Added support for binary response

### DIFF
--- a/lib/fastcgi.js
+++ b/lib/fastcgi.js
@@ -227,6 +227,9 @@ function Parser() {
                                                                         case "ascii":
                                                                                 _record.body = _body.asciiSlice(0, _record.header.contentLength);
                                                                                 break;
+									case "binary":
+										_record.body = _body.slice(0, _record.header.contentLength);
+										break;
                                                                         default:
                                                                                 _parser.onBody(_body, 0, _record.header.contentLength);
                                                                                 break;

--- a/lib/fastcgi.js
+++ b/lib/fastcgi.js
@@ -227,6 +227,9 @@ function Parser() {
                                                                         case "ascii":
                                                                                 _record.body = _body.asciiSlice(0, _record.header.contentLength);
                                                                                 break;
+									case "binary":
+										_record.body = _body.slice(0, _record.header.contentLength);
+										break;
                                                                         default:
                                                                                 _parser.onBody(_body, 0, _record.header.contentLength);
                                                                                 break;
@@ -341,9 +344,6 @@ function Writer() {
 				break;
 			case "utf8":
 				_pos += _buffer.utf8Write(body, _pos, _buffer.length - _pos);
-				break;
-			case "binary":
-				_record.body = _body.slice(0, _record.header.contentLength);
 				break;
 			default:
 				body.copy(_buffer, _pos);

--- a/lib/fastcgi.js
+++ b/lib/fastcgi.js
@@ -342,6 +342,9 @@ function Writer() {
 			case "utf8":
 				_pos += _buffer.utf8Write(body, _pos, _buffer.length - _pos);
 				break;
+			case "binary":
+				_record.body = _body.slice(0, _record.header.contentLength);
+				break;
 			default:
 				body.copy(_buffer, _pos);
 				_pos += body.length;


### PR DESCRIPTION
Allows encoding to be set to binary and pass in buffer rather than string. Solves a problem when returning binary files via fastcgi backend.